### PR TITLE
Add a replay indexer

### DIFF
--- a/src/exts/replay_handler.js
+++ b/src/exts/replay_handler.js
@@ -1,26 +1,13 @@
-const path = require('path');
-
-const { DemoParser } = require('sdfz-demo-parser');
-
 const { bridge } = require('../spring_api');
 const springPlatform = require('../spring_platform');
 const { log } = require('../spring_log');
+const { parseReplay } = require('../replay_utils');
 
 bridge.on('ReadReplayInfo', async command => {
 	try {
-		const demoPath = path.join(springPlatform.writePath, command.relativePath);
-		const parser = new DemoParser();
-		const demo = await parser.parseDemo(demoPath);
-
-		const info = {
-			relativePath : command.relativePath,
-			engine: demo.header.versionString,
-			game: demo.info.hostSettings.gametype,
-			map: demo.info.hostSettings.mapname,
-			players: demo.info.players.concat(demo.info.ais),
-			gameTime: demo.header.gameTime
-		};
-
+		const info = await parseReplay(
+			springPlatform.writePath, command.relativePath, false
+		);
 		bridge.send('ReplayInfo', info);
 	} catch (err) {
 		log.error(`Error parsing file: ${command.relativePath}`);

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const { log } = require('./spring_log');
 require('./error_handling');
 const { config } = require('./launcher_config');
 const { gui } = require('./launcher_gui');
+require('./worker/window');
 const { wizard } = require('./launcher_wizard');
 // Setup downloader bindings
 require('./launcher_downloader');

--- a/src/replay_utils.js
+++ b/src/replay_utils.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs').promises;
+const { constants } = require('fs');
+const path = require('path');
+
+const { DemoParser } = require('sdfz-demo-parser');
+
+// Parse a replay and create the needed info structure. If there is a cache
+// file for this replay, use it.
+async function parseReplay(springPath, replayPath, exitIfCacheExists) {
+	const fullReplayPath = path.join(springPath, replayPath);
+	const demoCachePath = `${fullReplayPath}.cache`;
+
+	try {
+		// Check if there is a cache file
+		await fs.access(demoCachePath, constants.R_OK);
+	} catch (err) {
+		// If there isn't, go parse the original replay, create the cache file,
+		// and return the info.
+		const parser = new DemoParser();
+		const demo = await parser.parseDemo(fullReplayPath);
+		const info = {
+			relativePath : replayPath,
+			engine: demo.header.versionString,
+			game: demo.info.hostSettings.gametype,
+			map: demo.info.hostSettings.mapname,
+			players: demo.info.players.concat(demo.info.ais),
+			gameTime: demo.header.gameTime
+		};
+
+		// Since there is no cache file yet, create it
+		fs.writeFile(demoCachePath, JSON.stringify(info));
+
+		return info;
+	}
+
+	// We found a cache file: return its content if asked for.
+	if (exitIfCacheExists) {
+		return null;
+	}
+	return JSON.parse(await fs.readFile(demoCachePath));
+}
+
+module.exports = {
+	parseReplay: parseReplay
+};

--- a/src/worker/index.html
+++ b/src/worker/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Launcher main worker</title>
+  </head>
+  <body>
+    <script>
+      require('./main')
+    </script>
+  </body>
+</html>
+

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const { ipcRenderer } = require('electron');
+
+const { parseReplay } = require('../replay_utils');
+
+// This worker's goal is to index the replays. For the moment, it simply goes
+// once over all the replays at start, and verifies that cache files exists
+// for them.
+//
+// Replays that weren't parsed & cached now will be via `ReadReplayInfo`
+// requests anyway, so we don't need to ensure that every replay is always
+// indexed.
+
+ipcRenderer.on('start-indexing-replays', (ev, springPath) => {
+	fs.readdir(path.join(springPath, 'demos'), (err, files) => {
+		files.forEach(async (file) => {
+			//	Skip non sdfz files (.cache files)
+			if (!file.endsWith('.sdfz')) {
+				return;
+			}
+
+			try {
+				// Parse replays, for the sole purpose of creating the cache files.
+				// We ignore the return value because we don't need it here, we're
+				// only interested in side effects.
+				parseReplay(springPath, path.join('demos', file), true);
+			} catch (err) {
+				console.error(`Error parsing file: ${file}`);
+			}
+		});
+	});
+});

--- a/src/worker/window.js
+++ b/src/worker/window.js
@@ -1,0 +1,26 @@
+const { app, BrowserWindow } = require('electron');
+const springPlatform = require('../spring_platform');
+
+let workerWindow;
+
+// Create a window for the worker
+
+app.prependListener('ready', () => {
+	workerWindow = new BrowserWindow({
+		show: false,
+		webPreferences: {nodeIntegration: true }
+	});
+	workerWindow.loadFile(`${__dirname}/index.html`);
+
+	// Send a 'start-indexing-replays' request once the worker is ready
+	workerWindow.once('ready-to-show', () => {
+		workerWindow.send('start-indexing-replays', springPlatform.writePath);
+	});
+
+});
+
+module.exports = {
+	getWorkerWindow: function() {
+		return workerWindow;
+	},
+};


### PR DESCRIPTION
* This replay indexer will add a `.cache` file for every `.sdfz` file in
  the `demos` folder, caching the info we need for every demo.

* The `ReadReplayInfo` request mostly doesn't change, but will try to
  read the cache file first. If it doesn't exist, it falls back on regular
  parsing.

* The logic of parsing/caching is factorized into an helper module.