### PR TITLE
Update electron from 16 to 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "yargs": "^15.4.1"
       },
       "devDependencies": {
-        "electron": "^16.0.6",
+        "electron": "^17.1.2",
         "electron-builder": "^22.14.5",
         "eslint": "^6.8.0",
         "jest": "^26.6.3"
@@ -3773,9 +3773,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.6.tgz",
-      "integrity": "sha512-Xs9dYLYhcJf3wXn8m2gDqFTb1L862KEhMxOx9swfFBHj6NoUPPtUgw/RyPQ0tXN1XPxG9vnBkoI0BdcKwrLKuQ==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -13911,9 +13911,9 @@
       }
     },
     "electron": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.6.tgz",
-      "integrity": "sha512-Xs9dYLYhcJf3wXn8m2gDqFTb1L862KEhMxOx9swfFBHj6NoUPPtUgw/RyPQ0tXN1XPxG9vnBkoI0BdcKwrLKuQ==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "yargs": "^15.4.1"
   },
   "devDependencies": {
-    "electron": "^16.0.6",
+    "electron": "^17.1.2",
     "electron-builder": "^22.14.5",
     "eslint": "^6.8.0",
     "jest": "^26.6.3"


### PR DESCRIPTION
https://github.com/electron/electron/pull/29618 got merged in version 17, plus a bunch of other wayland fixes, which allows to run launcher purely on wayland.

Not much changed in API: https://www.electronjs.org/blog/electron-17-0#breaking-changes