### PR TITLE
Add workaroung for wrong initial window size on linux/wayland

### DIFF
--- a/src/launcher_gui.js
+++ b/src/launcher_gui.js
@@ -109,6 +109,16 @@ app.prependListener('ready', () => {
 			gui.send('wizard-stopped');
 		}
 	});
+
+	// Workaround for linux/wayland on which electron has a problem with
+	// properly setting window size from the beggining and a simple size refresh
+	// after it got rendered once fixes it.
+	// TODO: check if it can be dropped once on electron >= 18.
+	mainWindow.once('show', () => {
+		setTimeout(() => {
+			mainWindow.setSize(width, height);
+		}, 0);
+	});
 });
 
 class GUI {


### PR DESCRIPTION
This will only make sense once wayland kind of starts working after #101 gets merged.

For all platforms except for linux/wayland this is effectively noop. Also on my machine I've not noticed any size flicker or anything like this when launching.