### PR TITLE
Update electron from 17.1.2 to 17.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "yargs": "^15.4.1"
       },
       "devDependencies": {
-        "electron": "^17.1.2",
+        "electron": "^17.4.3",
         "electron-builder": "^22.14.5",
         "eslint": "^6.8.0",
         "jest": "^26.6.3"
@@ -3756,9 +3756,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.3.tgz",
+      "integrity": "sha512-WQggyCgNUOzoOn+wJKe+xFhYy56gyrn/jIa/l7dyD3TxPb8lddSc86OAqPnP5EugcNXQ0yIu8b+SIE8duKozSw==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -13862,9 +13862,9 @@
       }
     },
     "electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.3.tgz",
+      "integrity": "sha512-WQggyCgNUOzoOn+wJKe+xFhYy56gyrn/jIa/l7dyD3TxPb8lddSc86OAqPnP5EugcNXQ0yIu8b+SIE8duKozSw==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "yargs": "^15.4.1"
   },
   "devDependencies": {
-    "electron": "^17.1.2",
+    "electron": "^17.4.3",
     "electron-builder": "^22.14.5",
     "eslint": "^6.8.0",
     "jest": "^26.6.3"


### PR DESCRIPTION
That's only patch update so no backward incompatible changes, I don't see any issues.

Motivation: It contains my fixed for running under Wayland https://github.com/electron/electron/pull/33355 and nobody detected any issues there so far, so we can experiment with runnning both game and launcher natively on wayland.

cc @Beherith, as you can imagine, would love to have it in the Wednesday release :wink: 