### PR TITLE
Make sure settings have empty line at the end

### DIFF
--- a/src/springsettings.js
+++ b/src/springsettings.js
@@ -20,6 +20,9 @@ class Springsettings extends EventEmitter {
 			// ignore errors
 		}
 		const lines = fileContent.split(/\r?\n/g);
+		if (lines[lines.length - 1] === '') {
+			lines.pop();
+		}
 		const settings = new Map();
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
@@ -49,7 +52,7 @@ class Springsettings extends EventEmitter {
 				throw new Error(`internal error: unexpected key in map: ${key}`);
 			}
 		}
-		fs.writeFileSync(springsettingsPath, result.join(os.EOL));
+		fs.writeFileSync(springsettingsPath, result.join(os.EOL) + os.EOL);
 	}
 
 	#applyDefaults(settings, defaults) {


### PR DESCRIPTION
...and also make sure we ignore it when loading. Emtpy line at the end is always automatically added by engine, and when we append new setting to the config file without ignoring it, we have a unnecerary empty line between the old and new settings.